### PR TITLE
Update example with missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It is expected that you use this in your `webpack.config.js` file.
 const webpack = require('webpack')
 const {getIfUtils, removeEmpty} = require('webpack-config-utils')
 
-const {ifProduction} = getIfUtils(process.env.NODE_ENV)
+const {ifProduction, ifNotProduction} = getIfUtils(process.env.NODE_ENV)
 
 module.exports = {
   // ... your config


### PR DESCRIPTION
ifNotProduction wasn't required, but is used in the example code. Apologies for not following the contribution guidelines, but it's a small doc fix I noticed. If it's an issue, I can resubmit tonight when I'm not busy with other stuff.